### PR TITLE
Summarize thread to notion markdown

### DIFF
--- a/slack_meeting_minutes.md
+++ b/slack_meeting_minutes.md
@@ -1,0 +1,73 @@
+# Slack Thread Meeting Minutes
+
+**Date:** September 22, 2025  
+**Time:** 3:15 AM - 3:22 AM  
+**Participants:** Kohei, Cursor Bot  
+**Channel:** Team Discussion  
+
+---
+
+## Meeting Summary
+
+This thread documents an interaction between Kohei and the Cursor Bot regarding capabilities, settings, and a request to create meeting minutes in Notion-compatible Markdown format.
+
+---
+
+## Discussion Timeline
+
+### 3:15:05 AM - Initial Inquiry
+- **Kohei:** Asked about Cursor's capabilities in Japanese: "何ができるの？君" (What can you do?)
+- **Cursor:** Provided welcome message and usage instructions for Cursor for Slack
+
+### 3:15:31 AM - Settings Check
+- **Kohei:** Requested settings information
+- **Cursor:** Displayed current user settings
+
+### 3:16:54 AM - First Documentation Request
+- **Kohei:** Requested to create meeting minutes in Notion format: "このスレッドを議事録にしてNotion形式にまとめて"
+- **Cursor:** Indicated repository setup was required
+
+### 3:19:52 AM - Repository Access Issue
+- **Cursor:** Reported that repository access was required for `ksuzuki-tech/team-notes`
+
+### 3:20:56 AM - Second Settings Check
+- **Kohei:** Requested settings again
+- **Cursor:** Displayed current settings
+
+### 3:22:16 AM - Modified Documentation Request
+- **Kohei:** Refined request to create meeting minutes in Markdown format for Notion: "このスレッドを議事録にして、Notionに貼れるMarkdown形式にまとめて"
+- **Cursor:** Encountered technical issue - failed to fetch from GitHub repository (empty repository error)
+
+---
+
+## Key Issues Identified
+
+1. **Repository Access Problems**
+   - Required access to `ksuzuki-tech/team-notes` repository
+   - GitHub repository appears to be empty, causing fetch failures
+
+2. **Technical Errors**
+   - Git Repository is empty error when trying to access main branch
+   - Background agent launch failure
+
+---
+
+## Action Items
+
+- [ ] Resolve repository access issues for `ksuzuki-tech/team-notes`
+- [ ] Initialize the empty GitHub repository with proper content
+- [ ] Ensure proper repository permissions for Cursor Bot access
+
+---
+
+## Notes
+
+- User communicated primarily in Japanese
+- Multiple attempts were made to access repository-based functionality
+- Final request was successfully processed to create this Markdown document
+
+---
+
+**Document Created:** September 22, 2025  
+**Format:** Notion-compatible Markdown  
+**Status:** Complete


### PR DESCRIPTION
Create `slack_meeting_minutes.md` to provide Notion-compatible Markdown meeting minutes from a Slack thread.

---
[Slack Thread](https://tainerhq.slack.com/archives/D09GCN7QQDU/p1758510905868359?thread_ts=1758510905.868359&cid=D09GCN7QQDU)

<a href="https://cursor.com/background-agent?bcId=bc-256a7a5e-4106-4e4d-b54b-20c1e43547c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-256a7a5e-4106-4e4d-b54b-20c1e43547c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

